### PR TITLE
Make glue file name configurable

### DIFF
--- a/annotation/src/main/java/io/github/landerlyoung/jenny/NativeClass.java
+++ b/annotation/src/main/java/io/github/landerlyoung/jenny/NativeClass.java
@@ -52,4 +52,39 @@ public @interface NativeClass {
      * @return use dynamic register or JNI function name conversions
      */
     boolean dynamicRegisterJniMethods() default true;
+
+    /**
+     * @return file naming strategy for glue code header/source files
+     */
+    FileNameStrategy fileNameStrategy() default FileNameStrategy.DEFAULT;
+
+    /**
+     * Valid file name strategies to use when generating glue code header/source files
+     */
+    enum FileNameStrategy {
+        /**
+         * Use naming strategy set in configuration
+         */
+        DEFAULT,
+        /**
+         * Jenny file name strategy
+         * <p>
+         * i.e.
+         * <ul>
+         *     <li>com.example.SomeClass -> SomeClass.h</li>
+         *     <li>com.example.SomeClass$InnerClass -> InnerClass.h</li>
+         * </ul>
+         */
+        JENNY,
+        /**
+         * javah file name strategy
+         * <p>
+         * i.e.
+         * <ul>
+         *     <li>com.example.SomeClass -> com_example_SomeClass.h</li>
+         *     <li>com.example.SomeClass$InnerClass -> com_example_SomeClass_InnerClass.h</li>
+         * </ul>
+         */
+        JAVAH
+    }
 }

--- a/compiler/src/main/java/io/github/landerlyoung/jenny/Configurations.kt
+++ b/compiler/src/main/java/io/github/landerlyoung/jenny/Configurations.kt
@@ -18,7 +18,8 @@ data class Configurations(
         val outputDirectory: String?,
         val fusionProxyHeaderName: String,
         val headerOnlyProxy: Boolean = true,
-        val useJniHelper: Boolean = false
+        val useJniHelper: Boolean = false,
+        val fileNameStrategy: NativeClass.FileNameStrategy = NativeClass.FileNameStrategy.JENNY
 ) {
     companion object {
         private const val PREFIX = "jenny."
@@ -39,13 +40,16 @@ data class Configurations(
 
         val USE_JNI_HELPER = PREFIX + Configurations::useJniHelper.name
 
+        val FILE_NAME_STRATEGY = PREFIX + Configurations::fileNameStrategy.name
+
         val ALL_OPTIONS = setOf(
                 THREAD_SAFE,
                 ERROR_LOGGER_FUNCTION,
                 OUTPUT_DIRECTORY,
                 FUSION_PROXY_HEADER_NAME,
                 HEADER_ONLY_PROXY,
-                USE_JNI_HELPER
+                USE_JNI_HELPER,
+                FILE_NAME_STRATEGY
         )
 
         fun fromOptions(options: Map<String, String>) = Configurations(
@@ -54,8 +58,12 @@ data class Configurations(
                 options[OUTPUT_DIRECTORY],
                 options[FUSION_PROXY_HEADER_NAME] ?: Constants.JENNY_FUSION_PROXY_HEADER_NAME,
                 options[HEADER_ONLY_PROXY] != false.toString(),
-                options[USE_JNI_HELPER] == true.toString()
-        )
+                options[USE_JNI_HELPER] == true.toString(),
+                options[FILE_NAME_STRATEGY]?.let {
+                    NativeClass.FileNameStrategy.values()
+                        .find { fileNameStrategy -> it.equals(fileNameStrategy.name, ignoreCase = true) }
+                } ?: NativeClass.FileNameStrategy.JENNY
+            )
 
         @JvmStatic
         fun main(args: Array<String>) {


### PR DESCRIPTION
Fixes #12 by adding an enum for predefined file naming strategies. The two strategies that are available currently are

- Jenny file name strategy: `com.example.SomeClass` -> `SomeClass.h`/`SomeClass.cpp`
- javah file name strategy: `com.example.SomeClass` -> `com_example_SomeClass.h`/`com_example_SomeClass.cpp`

The file name strategy can be set per `@NativeClass` via `@NativeClass(fileNameStrategy = NativeClass.FileNameStrategy.JAVAH)` or globally using the `jenny.fileNameStrategy=javah` configuration parameter.

If a global file name strategy is set using configuration and if a file name strategy is set via `@NativeClass`, then the file name strategy set via `@NativeClass` overrides the global file name strategy and is used for that class only when the glue code is generated.